### PR TITLE
Add startSlides prop to FadingSlides component to prevent memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import React from "react";
-import { StyleSheet, Text, Image, View, Animated, Easing } from "react-native";
-import PropTypes from "prop-types";
+import React from 'react';
+import { StyleSheet, Text, Image, View, Animated, Easing } from 'react-native';
+import PropTypes from 'prop-types';
 
 const MINIMUM_DELAY = 100;
 
@@ -11,7 +11,15 @@ export default class FadingSlides extends React.Component {
   };
 
   componentDidMount() {
-    this._wait(this._hide);
+    if (this.props.startSlides) {
+      this._wait(this._hide);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.startSlides) {
+      this._wait(this._hide);
+    }
   }
 
   _animate = (targetValue, cb) => {
@@ -38,7 +46,10 @@ export default class FadingSlides extends React.Component {
   _changeSlide = () => {
     let index = this.state.currentIndex + 1;
     index = index < this.props.slides.length ? index : 0;
-    this.setState({ currentIndex: index }, this._show);
+    if (this.props.startSlides) {
+      this.setState({ currentIndex: index }, this._show);
+      counter = index;
+    }
   };
 
   render() {
@@ -71,19 +82,19 @@ export default class FadingSlides extends React.Component {
 const styles = StyleSheet.create({
   slide: {
     flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    flexDirection: "column"
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column'
   },
   info: {
     flex: 1,
-    justifyContent: "flex-end",
-    alignItems: "center",
-    flexDirection: "column"
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    flexDirection: 'column'
   },
   title: {
     fontSize: 22,
-    fontWeight: "700"
+    fontWeight: '700'
   },
   subtitle: {
     fontSize: 20,
@@ -92,6 +103,7 @@ const styles = StyleSheet.create({
 });
 
 FadingSlides.propTypes = {
+  startSlides: PropTypes.bool,
   stillDuration: PropTypes.number,
   fadeDuration: PropTypes.number,
   height: PropTypes.number,
@@ -109,6 +121,7 @@ FadingSlides.propTypes = {
 };
 
 FadingSlides.defaultProps = {
+  startSlides: false,
   stillDuration: MINIMUM_DELAY,
   fadeDuration: MINIMUM_DELAY
 };

--- a/index.js
+++ b/index.js
@@ -11,13 +11,13 @@ export default class FadingSlides extends React.Component {
   };
 
   componentDidMount() {
-    if (this.props.startSlides) {
+    if (this.props.startAnimation) {
       this._wait(this._hide);
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.startSlides) {
+    if (nextProps.startAnimation) {
       this._wait(this._hide);
     }
   }
@@ -46,7 +46,7 @@ export default class FadingSlides extends React.Component {
   _changeSlide = () => {
     let index = this.state.currentIndex + 1;
     index = index < this.props.slides.length ? index : 0;
-    if (this.props.startSlides) {
+    if (this.props.startAnimation) {
       this.setState({ currentIndex: index }, this._show);
       counter = index;
     }
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
 });
 
 FadingSlides.propTypes = {
-  startSlides: PropTypes.bool,
+  startAnimation: PropTypes.bool,
   stillDuration: PropTypes.number,
   fadeDuration: PropTypes.number,
   height: PropTypes.number,
@@ -121,7 +121,7 @@ FadingSlides.propTypes = {
 };
 
 FadingSlides.defaultProps = {
-  startSlides: false,
+  startAnimation: false,
   stillDuration: MINIMUM_DELAY,
   fadeDuration: MINIMUM_DELAY
 };


### PR DESCRIPTION
@chagasaway - I figured out the issue that was causing the bug. I added a startSlides prop to FadingSlides to be able to stop the animation. Starting the animation on componentDidMount was triggering the memory leak error because the component would start calling `this.setState({})` even thought it wasn't ready and mounted. Once FadingSlides would get unmounted then Fading slides would continue call `this.setState({})`. This might be an edge case particular to my project but adding a way to stop the animation would take care of this problem. Please review the pull request to see the changes I'm suggesting. I'm sure they will need improvement and more testing.